### PR TITLE
Add flea market options

### DIFF
--- a/src/flea-controller.ts
+++ b/src/flea-controller.ts
@@ -1,6 +1,7 @@
 import type { DatabaseServer } from '@spt/servers/DatabaseServer';
 import type { ConfigServer } from '@spt/servers/ConfigServer';
 import type { ConfigTypes } from '@spt/models/enums/ConfigTypes';
+import type { Config } from './config';
 import { checkAccessVia } from './helpers';
 
 export class FleaController{

--- a/src/flea-controller.ts
+++ b/src/flea-controller.ts
@@ -1,0 +1,33 @@
+import type { DatabaseServer } from '@spt/servers/DatabaseServer';
+import type { ConfigServer } from '@spt/servers/ConfigServer';
+import type { ConfigTypes } from '@spt/models/enums/ConfigTypes';
+import { checkAccessVia } from './helpers';
+
+export class FleaController{
+
+	constructor(
+		private readonly db: DatabaseServer,
+		private readonly configServer: ConfigServer,
+	) {};
+
+	initFlea(config: Config): void {
+	
+		if (config.flea && config.flea.min_level)
+		{
+			const fleaConfig = this.db.getTables().globals.config.RagFair;
+			fleaConfig.minUserLevel = config.flea.min_level;
+		}
+		
+	};
+
+	updateFlea(
+		access_via: string | string[],
+		offraidPosition: string,
+	): void {
+
+		const fleaConfig = this.db.getTables().globals.config.RagFair;		
+		fleaConfig.enabled = checkAccessVia(access_via, offraidPosition);
+
+	}
+
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -185,6 +185,8 @@ class PathToTarkov implements IPreSptLoadMod, IPostSptLoadMod {
 
     this.pathToTarkovController.tradersController.initTraders(this.config);
 
+	this.pathToTarkovController.fleaController.initFlea(this.config);
+
     Object.keys(profiles).forEach(profileId => {
       this.pathToTarkovController.cleanupLegacySecondaryStashesLink(profileId);
     });

--- a/src/path-to-tarkov-controller.ts
+++ b/src/path-to-tarkov-controller.ts
@@ -19,6 +19,7 @@ import {
 
 import { getTemplateIdFromStashId, StashController } from './stash-controller';
 import { TradersController } from './traders-controller';
+import { FleaController } from './flea-controller';
 import type { DependencyContainer } from 'tsyringe';
 import type { LocationController } from '@spt/controllers/LocationController';
 import { deepClone, shuffle } from './utils';
@@ -60,6 +61,7 @@ const getIndexedLocations = (locations: ILocations): IndexedLocations => {
 export class PathToTarkovController {
   public stashController: StashController;
   public tradersController: TradersController;
+  public fleaController: FleaController;
 
   // configs are indexed by sessionId
   private configCache: Record<string, Config> = {};
@@ -99,6 +101,10 @@ export class PathToTarkovController {
       configServer,
       this.logger,
     );
+	this.fleaController = new FleaController(
+		db,
+		configServer,
+	);
     this.overrideControllers();
   }
 
@@ -243,6 +249,12 @@ export class PathToTarkovController {
       offraidPosition,
       sessionId,
     );
+
+	if (config.flea && config.flea.access_via)
+		this.fleaController.updateFlea(
+		  config.flea.access_via,
+		  offraidPosition,
+		);
 
     this.saveServer.saveProfile(sessionId);
   }


### PR DESCRIPTION
Adds flea market options in config file:
"flea": {
min_level: number, Minimum level required to access flea market
access_via: string[] Offraid positions, same format of trader.access_via
}

If any config options are not found, will leave as default (minimum level 15, available everywhere.)

This is my first ever attempt at a Git code contribution so sincere apologies if I've messed up any protocols!